### PR TITLE
Re-implement the audit logging feature.

### DIFF
--- a/db/migrations/013_add_object_id_to_audit_records.rb
+++ b/db/migrations/013_add_object_id_to_audit_records.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:audit_records) do
+      add_column :object_id, Integer
+    end
+  end
+end

--- a/db/migrations/014_add_prev_new_object_to_audit_records.rb
+++ b/db/migrations/014_add_prev_new_object_to_audit_records.rb
@@ -1,0 +1,8 @@
+Sequel.migration do
+  change do
+    alter_table(:audit_records) do
+      add_column :old_object, String
+      add_column :new_object, String
+    end
+  end
+end

--- a/db/migrations/015_remove_params_from_audit_records.rb
+++ b/db/migrations/015_remove_params_from_audit_records.rb
@@ -1,0 +1,16 @@
+Sequel.migration do
+  up do
+    alter_table(:audit_records) do
+      drop_column :params
+    end
+
+    db = Bandiera::Db.connect
+    db[:audit_records].truncate
+  end
+
+  down do
+    alter_table(:audit_records) do
+      add_column :params, String, text: true
+    end
+  end
+end

--- a/lib/bandiera/blackhole_audit_log.rb
+++ b/lib/bandiera/blackhole_audit_log.rb
@@ -1,5 +1,15 @@
 module Bandiera
   class BlackholeAuditLog
-    def record(_audit_context, _action, _object_name, _params) end
+    def record_add_object(_audit_context, _object)
+      # no-op
+    end
+
+    def record_update_object(_audit_context, _old_object, _new_object)
+      # no-op
+    end
+
+    def record_delete_object(_audit_context, _object)
+      # no-op
+    end
   end
 end

--- a/lib/bandiera/feature.rb
+++ b/lib/bandiera/feature.rb
@@ -2,6 +2,7 @@ module Bandiera
   class Feature < Sequel::Model
     many_to_one :group
 
+    plugin :json_serializer
     plugin :serialization
     plugin :timestamps, create: :created_at, update: :updated_at, update_on_create: true
 

--- a/lib/bandiera/group.rb
+++ b/lib/bandiera/group.rb
@@ -1,5 +1,7 @@
 module Bandiera
   class Group < Sequel::Model
     one_to_many :features, order: Sequel.asc(:name)
+
+    plugin :json_serializer
   end
 end

--- a/spec/lib/bandiera/db_spec.rb
+++ b/spec/lib/bandiera/db_spec.rb
@@ -25,24 +25,6 @@ RSpec.describe Bandiera::Db do
     end
   end
 
-  describe 'the audit records table' do
-    it 'should be present' do
-      expect(subject.tables).to include(:audit_records)
-    end
-
-    it 'should be empty' do
-      expect(subject[:audit_records]).to be_empty
-    end
-
-    it 'should allow us to enter data' do
-      subject[:audit_records] <<
-        { timestamp: Time.now, user: 'test1', action: 'add', object: 'feature', params: 'name: feature1' }
-      subject[:audit_records] <<
-        { timestamp: Time.now, user: 'test2', action: 'delete', object: 'feature', params: 'name: feature1' }
-      expect(subject[:audit_records].count).to eq(2)
-    end
-  end
-
   describe '#ready?' do
     context 'when the database is up and ready' do
       it 'returns true' do

--- a/spec/lib/bandiera/feature_service_spec.rb
+++ b/spec/lib/bandiera/feature_service_spec.rb
@@ -2,27 +2,25 @@ require 'spec_helper'
 
 RSpec.describe Bandiera::FeatureService do
   let(:audit_context) { Bandiera::AnonymousAuditContext.new }
-  let(:audit_log) { instance_double('Bandiera::AuditLog') }
+  let(:audit_log) { Bandiera::LoggingAuditLog.new }
   subject { Bandiera::FeatureService.new(audit_log) }
-
-  before do
-    allow(audit_log).to receive(:record)
-  end
 
   it_behaves_like 'a feature service'
 
   describe '#add_group' do
     it 'records to the audit log' do
-      expect(audit_log).to receive(:record).with(audit_context, :add, :group, name: 'cheese')
-
+      expect(audit_log).to receive(:record_add_object).once
       subject.add_group(audit_context, 'cheese')
     end
   end
 
   describe '#add_feature' do
     it 'records to the audit log' do
-      expect(audit_log).to receive(:record)
-        .with(audit_context, :add, :feature, name: 'feat', group: 'group', active: false)
+      subject.add_group(audit_context, 'group')
+
+      expect(audit_log)
+        .to receive(:record_add_object)
+        .with(audit_context, instance_of(Bandiera::Feature))
 
       subject.add_feature(audit_context, name: 'feat', group: 'group', active: false)
     end
@@ -30,41 +28,40 @@ RSpec.describe Bandiera::FeatureService do
 
   describe '#add_features' do
     it 'records to the audit log' do
-      expect(audit_log).to receive(:record)
-        .with(audit_context, :add, :feature, name: 'feature1', group: 'group_name', active: nil)
-        .with(audit_context, :add, :feature, name: 'feature2', group: 'group_name', active: nil)
-        .with(audit_context, :add, :feature, name: 'wibble', group: 'something_else', active: nil)
+      subject.add_group(audit_context, 'group')
+
+      expect(audit_log)
+        .to receive(:record_add_object)
+        .with(audit_context, instance_of(Bandiera::Feature))
+        .exactly(3).times
 
       subject.add_features(audit_context, [
-          { name: 'feature1', group: 'group_name' },
-          { name: 'feature2', group: 'group_name' },
-          { name: 'wibble', group: 'something_else' }
+        { name: 'feature1', group: 'group' },
+        { name: 'feature2', group: 'group' },
+        { name: 'feature3', group: 'group' }
       ])
     end
   end
 
   describe '#remove_feature' do
-    before do
-      subject.add_feature(audit_context, { name: 'feat', group: 'group', description: '', active: false })
-    end
-
     it 'records to the audit log' do
-      expect(audit_log).to receive(:record)
-        .with(audit_context, :remove, :feature, name: 'feat', group: 'group')
+      subject.add_feature(audit_context, { name: 'feat', group: 'group', description: '', active: false })
+
+      expect(audit_log)
+        .to receive(:record_delete_object)
+        .with(audit_context, instance_of(Bandiera::Feature))
 
       subject.remove_feature(audit_context, 'group', 'feat')
     end
   end
 
   describe '#update_feature' do
-    before do
-      subject.add_feature(audit_context, { name: 'feat', group: 'group', description: '', active: false })
-    end
-
     it 'records to the audit log' do
-      expect(audit_log).to receive(:record)
-        .with(audit_context, :update, :feature, name: 'feat', group: 'group',
-          fields: { description: 'updated', active: true })
+      subject.add_feature(audit_context, { name: 'feat', group: 'group', description: '', active: false })
+
+      expect(audit_log)
+        .to receive(:record_update_object)
+        .with(audit_context, instance_of(Bandiera::Feature), instance_of(Bandiera::Feature))
 
       subject.update_feature(audit_context, 'group', 'feat', description: 'updated', active: true)
     end

--- a/spec/lib/bandiera/logging_audit_log_spec.rb
+++ b/spec/lib/bandiera/logging_audit_log_spec.rb
@@ -5,20 +5,38 @@ RSpec.describe Bandiera::LoggingAuditLog do
   let(:audit_context) { Bandiera::AnonymousAuditContext.new }
   subject { Bandiera::LoggingAuditLog.new(db) }
 
+  let(:group_obj) { Bandiera::Group.create(name: 'foo') }
+  let(:feature_obj) { Bandiera::Feature.create(group: group_obj, name: 'foo-feat', active: true)}
+
   it_behaves_like 'an audit log'
 
-  describe '#record' do
-    it 'records the audit message to the audit log' do
+  describe '#record_add_object' do
+    it 'records the creation of a new group object to the audit log' do
       expect(db[:audit_records]).to be_empty
 
-      subject.record(audit_context, :add, :foodstuff, name: 'burger')
+      subject.record_add_object(audit_context, group_obj)
 
       audit_record = db[:audit_records].first
       expect(audit_record).to_not be_nil
       expect(audit_record[:user]).to eq('<anonymous>')
-      expect(audit_record[:action]).to eq('add')
-      expect(audit_record[:object]).to eq('foodstuff')
-      expect(JSON.parse(audit_record[:params]).symbolize_keys).to eq({ name: 'burger' })
+      expect(audit_record[:action]).to eq('create')
+      expect(audit_record[:object]).to eq('Bandiera::Group')
+      expect(audit_record[:object_id]).to eq(group_obj.id)
+      expect(audit_record[:new_object]).to eq(group_obj.to_json)
+    end
+
+    it 'records the creation of a new feature object to the audit log' do
+      expect(db[:audit_records]).to be_empty
+
+      subject.record_add_object(audit_context, feature_obj)
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:user]).to eq('<anonymous>')
+      expect(audit_record[:action]).to eq('create')
+      expect(audit_record[:object]).to eq('Bandiera::Feature')
+      expect(audit_record[:object_id]).to eq(feature_obj.id)
+      expect(audit_record[:new_object]).to eq(feature_obj.to_json(except: [:created_at, :updated_at]))
     end
 
     it 'sets the timestamp to the current time' do
@@ -26,7 +44,7 @@ RSpec.describe Bandiera::LoggingAuditLog do
       expected_time = Time.local(2017, 1, 1, 12, 0, 0)
 
       Timecop.freeze(expected_time) do
-        subject.record(audit_context, :add, :foodstuff, name: 'burger')
+        subject.record_add_object(audit_context, feature_obj)
       end
 
       audit_record = db[:audit_records].first
@@ -34,32 +52,126 @@ RSpec.describe Bandiera::LoggingAuditLog do
       expect(audit_record[:timestamp]).to eq(expected_time)
     end
 
-    it 'handles no parameters' do
-      expect(db[:audit_records]).to be_empty
-
-      subject.record(audit_context, :add, :foodstuff)
-
-      audit_record = db[:audit_records].first
-      expect(audit_record).to_not be_nil
-      expect(audit_record[:params]).to be_nil
-    end
-
-    it 'handles multiple parameters' do
-      expect(db[:audit_records]).to be_empty
-
-      subject.record(audit_context, :add, :foodstuff, name: 'burger', type: 'rare')
-
-      audit_record = db[:audit_records].first
-      expect(audit_record).to_not be_nil
-      expect(JSON.parse(audit_record[:params]).symbolize_keys).to eq({ name: 'burger', type: 'rare' })
-    end
-
-    it 'does not propagate exceptions' do
+    it 'does not propogate exceptions' do
       audit_record = instance_double('Bandiera::AuditRecord')
-      expect(Bandiera::AuditRecord).to receive(:new).and_return(audit_record)
-      expect(audit_record).to receive(:save).and_throw RuntimeError.new('This should not propagate')
+      expect(Bandiera::AuditRecord).to receive(:create).and_throw RuntimeError.new('This should not propagate')
 
-      subject.record(audit_context, :add, :foodstuff, name: 'burger')
+      subject.record_add_object(audit_context, feature_obj)
+    end
+  end
+
+  describe '#record_update_object' do
+    it 'records the update of a group object to the audit log' do
+      expect(db[:audit_records]).to be_empty
+
+      older = group_obj.dup
+      older_json = older.to_json(except: [:created_at, :updated_at])
+      newer = group_obj.update(name: 'bar')
+      newer_json = newer.to_json(except: [:created_at, :updated_at])
+
+      subject.record_update_object(audit_context, older, newer)
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:user]).to eq('<anonymous>')
+      expect(audit_record[:action]).to eq('update')
+      expect(audit_record[:object]).to eq('Bandiera::Group')
+      expect(audit_record[:object_id]).to eq(older.id)
+      expect(audit_record[:old_object]).to eq(older_json)
+      expect(audit_record[:new_object]).to eq(newer_json)
+    end
+
+    it 'records the update of a feature object to the audit log' do
+      expect(db[:audit_records]).to be_empty
+
+      older = feature_obj.dup
+      older_json = older.to_json(except: [:created_at, :updated_at])
+      newer = feature_obj.update(name: 'bar-feat')
+      newer_json = newer.to_json(except: [:created_at, :updated_at])
+
+      subject.record_update_object(audit_context, older, newer)
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:user]).to eq('<anonymous>')
+      expect(audit_record[:action]).to eq('update')
+      expect(audit_record[:object]).to eq('Bandiera::Feature')
+      expect(audit_record[:object_id]).to eq(older.id)
+      expect(audit_record[:old_object]).to eq(older_json)
+      expect(audit_record[:new_object]).to eq(newer_json)
+    end
+
+    it 'sets the timestamp to the current time' do
+      expect(db[:audit_records]).to be_empty
+      expected_time = Time.local(2017, 1, 1, 12, 0, 0)
+
+      older = feature_obj.dup
+      newer = feature_obj.update(name: 'bar-feat')
+
+      Timecop.freeze(expected_time) do
+        subject.record_update_object(audit_context, older, newer)
+      end
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:timestamp]).to eq(expected_time)
+    end
+
+    it 'does not propogate exceptions' do
+      audit_record = instance_double('Bandiera::AuditRecord')
+      expect(Bandiera::AuditRecord).to receive(:create).and_throw RuntimeError.new('This should not propagate')
+
+      subject.record_update_object(audit_context, feature_obj, feature_obj)
+    end
+  end
+
+  describe '#record_delete_object' do
+    it 'records the deletion of a group object to the audit log' do
+      expect(db[:audit_records]).to be_empty
+
+      subject.record_delete_object(audit_context, group_obj)
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:user]).to eq('<anonymous>')
+      expect(audit_record[:action]).to eq('delete')
+      expect(audit_record[:object]).to eq('Bandiera::Group')
+      expect(audit_record[:object_id]).to eq(group_obj.id)
+      expect(audit_record[:old_object]).to eq(group_obj.to_json)
+    end
+
+    it 'records the deletion of a feature object to the audit log' do
+      expect(db[:audit_records]).to be_empty
+
+      subject.record_delete_object(audit_context, feature_obj)
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:user]).to eq('<anonymous>')
+      expect(audit_record[:action]).to eq('delete')
+      expect(audit_record[:object]).to eq('Bandiera::Feature')
+      expect(audit_record[:object_id]).to eq(feature_obj.id)
+      expect(audit_record[:old_object]).to eq(feature_obj.to_json(except: [:created_at, :updated_at]))
+    end
+
+    it 'sets the timestamp to the current time' do
+      expect(db[:audit_records]).to be_empty
+      expected_time = Time.local(2017, 1, 1, 12, 0, 0)
+
+      Timecop.freeze(expected_time) do
+        subject.record_delete_object(audit_context, feature_obj)
+      end
+
+      audit_record = db[:audit_records].first
+      expect(audit_record).to_not be_nil
+      expect(audit_record[:timestamp]).to eq(expected_time)
+    end
+
+    it 'does not propogate exceptions' do
+      audit_record = instance_double('Bandiera::AuditRecord')
+      expect(Bandiera::AuditRecord).to receive(:create).and_throw RuntimeError.new('This should not propagate')
+
+      subject.record_delete_object(audit_context, feature_obj)
     end
   end
 end

--- a/spec/shared_examples/an_audit_log.rb
+++ b/spec/shared_examples/an_audit_log.rb
@@ -2,8 +2,16 @@
 
 shared_examples_for 'an audit log' do
   describe 'logging methods' do
-    it 'responds to #record?' do
-      should respond_to(:record).with(4).arguments
+    it 'responds to #record_add_object' do
+      should respond_to(:record_add_object).with(2).arguments
+    end
+
+    it 'responds to #record_update_object' do
+      should respond_to(:record_update_object).with(3).arguments
+    end
+
+    it 'responds to #record_delete_object' do
+      should respond_to(:record_delete_object).with(2).arguments
     end
   end
 end


### PR DESCRIPTION
This now tracks the ID of the object that has been changed, and the full state of the object before and after.

Unfortunately there was no way I could retain backwards compatibility with the old model so I've had to truncate the `audit_records` table as part of one of the migrations.

This will mean a MAJOR version bump I guess - might as well make audit records default to on as part of that release.

resolves #22 and #27