### PR TITLE
Remove the syslog logger - now just log to stdout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ USER bandiera
 ENV prometheus_multiproc_dir=/tmp/prometheus_multiproc_dir
 RUN mkdir ${prometheus_multiproc_dir}
 
-ENV RACK_ENV=production LOG_TO_STDOUT=true
+ENV RACK_ENV=production
 
 EXPOSE 5000
 

--- a/HISTORY
+++ b/HISTORY
@@ -2,6 +2,8 @@
 
 Re-implementation of the audit logging feature - this unfortunately is a backwards incompatible change, hence the major version bump. As part of the database migration it **will** truncate your audit_records table. Audit logging is now permanently on (with no option to remove).
 
+We have removed the syslog logging capabilities from Bandiera and now default to logging to STDOUT. This is the norm for containerised applications and running via a container is our recommended deployment option.
+
 = 3.5.11 / 2021-10-18
 
 Update target ruby version to 2.7.4 and update (gem) dependencies.

--- a/lib/bandiera.rb
+++ b/lib/bandiera.rb
@@ -2,7 +2,6 @@ require 'dotenv'
 require 'json'
 require 'logger'
 require 'sequel'
-require 'syslog-logger'
 require_relative 'hash'
 
 GC::Profiler.enable
@@ -31,11 +30,7 @@ module Bandiera
     def logger
       return @logger if @logger
 
-      @logger = if ENV['LOG_TO_STDOUT']
-                  Logger.new($stdout)
-                else
-                  Logger::Syslog.new('bandiera', Syslog::LOG_LOCAL0)
-                end
+      @logger = Logger.new($stdout)
 
       if ENV['STACKDRIVER_JSON_LOGGER']
         require 'logger/stackdriver_json_formatter'


### PR DESCRIPTION
This is the norm for dockerised applications...

resolves #25